### PR TITLE
Use v3 to publish member attr

### DIFF
--- a/clientv3/integration/kv_test.go
+++ b/clientv3/integration/kv_test.go
@@ -893,7 +893,7 @@ func TestKVLargeRequests(t *testing.T) {
 		expectError error
 	}{
 		{
-			maxRequestBytesServer:  1,
+			maxRequestBytesServer:  256,
 			maxCallSendBytesClient: 0,
 			maxCallRecvBytesClient: 0,
 			valueSize:              1024,

--- a/etcdserver/api/membership/cluster.go
+++ b/etcdserver/api/membership/cluster.go
@@ -247,7 +247,7 @@ func (c *RaftCluster) Recover(onSet func(*zap.Logger, *semver.Version)) {
 	defer c.Unlock()
 
 	c.members, c.removed = membersFromStore(c.lg, c.v2store)
-	c.version = clusterVersionFromStore(c.lg, c.v2store)
+	c.version = clusterVersionFromBackend(c.lg, c.be)
 	mustDetectDowngrade(c.lg, c.version)
 	onSet(c.lg, c.version)
 
@@ -751,6 +751,26 @@ func clusterVersionFromStore(lg *zap.Logger, st v2store.Store) *semver.Version {
 		}
 	}
 	return semver.Must(semver.NewVersion(*e.Node.Value))
+}
+
+func clusterVersionFromBackend(lg *zap.Logger, be backend.Backend) *semver.Version {
+	ckey := backendClusterVersionKey()
+	tx := be.ReadTx()
+	tx.RLock()
+	defer tx.RUnlock()
+	keys, vals := tx.UnsafeRange(clusterBucketName, ckey, nil, 0)
+	if len(keys) == 0 {
+		return nil
+	}
+	if len(keys) != 1 {
+		if lg != nil {
+			lg.Panic(
+				"unexpected number of keys when getting cluster version from backend",
+				zap.Int("number fo keys", len(keys)),
+			)
+		}
+	}
+	return semver.Must(semver.NewVersion(string(vals[0])))
 }
 
 // ValidateClusterAndAssignIDs validates the local cluster by matching the PeerURLs

--- a/integration/v3_grpc_test.go
+++ b/integration/v3_grpc_test.go
@@ -1898,7 +1898,7 @@ func TestV3LargeRequests(t *testing.T) {
 		expectError     error
 	}{
 		// don't set to 0. use 0 as the default.
-		{1, 1024, rpctypes.ErrGRPCRequestTooLarge},
+		{256, 1024, rpctypes.ErrGRPCRequestTooLarge},
 		{10 * 1024 * 1024, 9 * 1024 * 1024, nil},
 		{10 * 1024 * 1024, 10 * 1024 * 1024, rpctypes.ErrGRPCRequestTooLarge},
 		{10 * 1024 * 1024, 10*1024*1024 + 5, rpctypes.ErrGRPCRequestTooLarge},


### PR DESCRIPTION
1. use v3 to publish member attributes

2. recover cluster version from backend
I am little worried about this one. In case of upgrade, the existing data directory already have v2 PUT requests for cluster version which are generated by the old server. The new server will first read cluster version from backend, then replay the v2 requests for cluster version. Maybe we should remove the v2 apply for cluster version update? 